### PR TITLE
Fix `cstVisitor`'s node check for `null` values

### DIFF
--- a/src/cstVisitor.ts
+++ b/src/cstVisitor.ts
@@ -39,5 +39,4 @@ export function cstVisitor(map: Partial<FullVisitorMap>): (node: Node) => void {
   return visit;
 }
 
-const isNode = (value: any): value is Node =>
-  typeof value === "object" && typeof value.type === "string";
+const isNode = (value: any): value is Node => typeof value?.type === "string";

--- a/test/cstVisitor.test.ts
+++ b/test/cstVisitor.test.ts
@@ -2,6 +2,16 @@ import { cstVisitor } from "../src/main";
 import { parse, preserveAll, show } from "./test_utils";
 
 describe("cstVisitor", () => {
+  it("supports `null_literal`)", () => {
+    const nulls: string[] = [];
+    const visit = cstVisitor({
+      null_literal: (node) => nulls.push(node.text),
+    });
+
+    visit(parse("SELECT * FROM employees WHERE id IS NULL"));
+    expect(nulls).toEqual(["NULL"]);
+  });
+
   it("allows visiting all identifiers", () => {
     const tables: string[] = [];
 


### PR DESCRIPTION
`NullLiteral.value` is `null` which would cause the `cstVisitor` to throw.

Thanks for developing this parser! Looks really promising 👍 