### PR TITLE
Support User-Defined Variables for mysql

### DIFF
--- a/src/cst/ProceduralLanguage.ts
+++ b/src/cst/ProceduralLanguage.ts
@@ -9,6 +9,7 @@ import {
   FuncCall,
   CaseWhen,
   CaseElse,
+  Variable,
 } from "./Expr";
 import { StringLiteral } from "./Literal";
 import { Program } from "./Program";
@@ -92,7 +93,13 @@ export interface SetStmt extends BaseNode {
   type: "set_stmt";
   setKw: Keyword<"SET">;
   assignments: ListExpr<
-    BinaryExpr<Identifier | ParenExpr<ListExpr<Identifier>>, "=", Expr>
+    BinaryExpr<
+      | Identifier
+      | Variable
+      | ParenExpr<ListExpr<Identifier> | ParenExpr<ListExpr<Variable>>>,
+      "=",
+      Expr
+    >
   >;
 }
 

--- a/src/parser.pegjs
+++ b/src/parser.pegjs
@@ -4457,7 +4457,7 @@ set_stmt
   }
 
 set_assignment
-  = name:((ident / paren$list$ident) __) "=" value:(__ expr) {
+  = name:((ident / variable / paren$list$ident / paren$list$variable) __) "=" value:(__ expr) {
     return loc({
       type: "binary_expr",
       left: read(name),
@@ -6852,6 +6852,7 @@ paren$list$string_literal = .
 paren$list$table_func_call = .
 paren$list$table_option_postgresql = .
 paren$list$tablesample_arg = .
+paren$list$variable = .
 paren$list$view_column_definition = .
 paren$pivot_for_in = .
 paren$postgresql_op = .

--- a/src/parser.pegjs
+++ b/src/parser.pegjs
@@ -4457,7 +4457,15 @@ set_stmt
   }
 
 set_assignment
-  = name:((ident / variable / paren$list$ident / paren$list$variable) __) "=" value:(__ expr) {
+  = &mysql name:((ident / variable / paren$list$ident / paren$list$variable) __) "=" value:(__ expr) {
+    return loc({
+      type: "binary_expr",
+      left: read(name),
+      operator: "=",
+      right: read(value),
+    })
+  }
+  / !mysql name:((ident / paren$list$ident) __) "=" value:(__ expr) {
     return loc({
       type: "binary_expr",
       left: read(name),

--- a/test/proc/set.test.ts
+++ b/test/proc/set.test.ts
@@ -24,12 +24,12 @@ describe("SET", () => {
       testWc("SET @x = 10");
     });
 
-    // it("supports subquery SET statement", () => {
-    //   testWc("SET @total_tax = (SELECT SUM(tax) FROM taxable_transactions)");
-    // });
-
     it("supports multiple assignments", () => {
       testWc("SET @x = 1, @y = 'foo', @z = false");
+    });
+
+    it("supports scalar subquery", () => {
+      testWc("SET @total_tax = (SELECT SUM(tax) FROM taxable_transactions)");
     });
   });
 

--- a/test/proc/set.test.ts
+++ b/test/proc/set.test.ts
@@ -19,7 +19,7 @@ describe("SET", () => {
     });
   });
 
-  dialect("mysql", () => {
+  dialect(["mysql", "mariadb"], () => {
     it("supports SET statement", () => {
       testWc("SET @x = 10");
     });
@@ -29,7 +29,7 @@ describe("SET", () => {
     });
 
     it("supports scalar subquery", () => {
-      testWc("SET @total_tax = (SELECT SUM(tax) FROM taxable_transactions)");
+      testWc("SET @sum_age = (SELECT SUM(age) FROM user)");
     });
   });
 

--- a/test/proc/set.test.ts
+++ b/test/proc/set.test.ts
@@ -1,7 +1,7 @@
 import { dialect, parse, testWc } from "../test_utils";
 
 describe("SET", () => {
-  dialect(["mysql", "mariadb", "bigquery"], () => {
+  dialect(["mariadb", "bigquery"], () => {
     it("supports SET statement", () => {
       testWc("SET x = 10");
     });
@@ -12,12 +12,28 @@ describe("SET", () => {
       });
     });
 
-    dialect(["mysql", "mariadb"], () => {
+    dialect("mariadb", () => {
       it("supports multiple assignments", () => {
         testWc("SET x = 1, y = 'foo', z = false");
       });
     });
   });
+
+  dialect("mysql", () => {
+    it("supports SET statement", () => {
+      testWc("SET @x = 10");
+    });
+
+    // it("supports subquery SET statement", () => {
+    //   testWc("SET @total_tax = (SELECT SUM(tax) FROM taxable_transactions)");
+    // });
+
+    it("supports multiple assignments", () => {
+      testWc("SET @x = 1, @y = 'foo', @z = false");
+    });
+  });
+
+
 
   dialect("sqlite", () => {
     it("does not support SET statement", () => {

--- a/test/proc/set.test.ts
+++ b/test/proc/set.test.ts
@@ -33,8 +33,6 @@ describe("SET", () => {
     });
   });
 
-
-
   dialect("sqlite", () => {
     it("does not support SET statement", () => {
       expect(() => parse("SET x = 1")).toThrowError();

--- a/test/proc/set.test.ts
+++ b/test/proc/set.test.ts
@@ -1,7 +1,7 @@
 import { dialect, parse, testWc } from "../test_utils";
 
 describe("SET", () => {
-  dialect(["mariadb", "bigquery"], () => {
+  dialect(["mysql", "mariadb", "bigquery"], () => {
     it("supports SET statement", () => {
       testWc("SET x = 10");
     });
@@ -12,7 +12,7 @@ describe("SET", () => {
       });
     });
 
-    dialect("mariadb", () => {
+    dialect(["mysql", "mariadb"], () => {
       it("supports multiple assignments", () => {
         testWc("SET x = 1, y = 'foo', z = false");
       });


### PR DESCRIPTION
For mysql (and mariadb), variables @foo can now be defined as user-defined functions.


specification
- https://dev.mysql.com/doc/refman/8.4/en/user-variables.html
- https://mariadb.com/kb/en/user-defined-variables/