### PR TITLE
add prettier check setting

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:@typescript-eslint/recommended-requiring-type-checking"
+    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+    "prettier"
   ],
   "overrides": [],
   "parser": "@typescript-eslint/parser",

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 /lib
 /node_modules
 /src/dialects/*.js
+/src/parser.ts
 changelog.hbs

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "auto-changelog": "^2.4.0",
     "benchmark": "^2.1.4",
     "eslint": "^8.30.0",
+    "eslint-config-prettier": "^9.1.0",
     "jest": "^29.1.2",
     "npm-watch": "^0.11.0",
     "peggy": "^3.0.2",

--- a/src/cstTransformer.ts
+++ b/src/cstTransformer.ts
@@ -29,7 +29,7 @@ export type TransformMap<T, TNode extends Node = Node> = Partial<
 export function cstTransformer<T>(map: TransformMap<T>): (node: Node) => T {
   return (node: Node) => {
     const fn = map[node.type] as (
-      param: NodeByType<typeof node["type"], Node>
+      param: NodeByType<(typeof node)["type"], Node>
     ) => T;
     if (!fn) {
       if (!node.type) {

--- a/src/cstVisitor.ts
+++ b/src/cstVisitor.ts
@@ -27,7 +27,7 @@ export type FullVisitorMap = {
 export function cstVisitor(map: Partial<FullVisitorMap>): (node: Node) => void {
   const visit = (node: Node) => {
     const visitType = map[node.type] as (
-      e: Extract<Node, { type: typeof node["type"] }>
+      e: Extract<Node, { type: (typeof node)["type"] }>
     ) => VisitorAction | void;
 
     // Visit the node itself

--- a/yarn.lock
+++ b/yarn.lock
@@ -1342,6 +1342,11 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+eslint-config-prettier@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz#31af3d94578645966c082fcb71a5846d3c94867f"
+  integrity sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
I did three things

- Ignore src/parser.ts from prettier. Reason for parser.ts is generated file and parser.ts is a large file, so it takes time to search.
- add prettier setting to eslint setting. prettier will now run via exlint in ci.
- Just execute npm run pretty.

