### PR TITLE
support GROUP BY ALL in BigQuery

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "sql-parser-cst",
   "description": "Parses SQL into Concrete Syntax Tree (CST)",
   "license": "GPL-2.0-or-later",
-  "version": "0.31.1",
+  "version": "0.32.0",
   "main": "lib/main.js",
   "types": "lib/main.d.ts",
   "repository": {

--- a/src/cst/Select.ts
+++ b/src/cst/Select.ts
@@ -44,6 +44,7 @@ export type AllSelectNodes =
   | GroupByRollup
   | GroupByCube
   | GroupByGroupingSets
+  | GroupByAll
   | HavingClause
   | WindowClause
   | QualifyClause
@@ -276,7 +277,12 @@ export interface GroupByClause extends BaseNode {
   withRollupKw?: [Keyword<"WITH">, Keyword<"ROLLUP">]; // MySQL, MariaDB
 }
 
-type GroupingElement = Expr | GroupByRollup | GroupByCube | GroupByGroupingSets;
+type GroupingElement =
+  | Expr
+  | GroupByRollup
+  | GroupByCube
+  | GroupByGroupingSets
+  | GroupByAll;
 
 // BigQuery, PostgreSQL
 export interface GroupByRollup extends BaseNode {
@@ -290,6 +296,12 @@ export interface GroupByCube extends BaseNode {
   type: "group_by_cube";
   cubeKw: Keyword<"CUBE">;
   columns: ParenExpr<ListExpr<Expr>>;
+}
+
+// BigQuery
+export interface GroupByAll extends BaseNode {
+  type: "group_by_all";
+  allKw: Keyword<"ALL">;
 }
 
 // PostgreSQL

--- a/src/parser.pegjs
+++ b/src/parser.pegjs
@@ -913,6 +913,7 @@ grouping_element
   = group_by_rollup
   / group_by_cube
   / group_by_grouping_sets
+  / group_by_all &bigquery
   / paren$empty_list
   / expr
 
@@ -940,6 +941,14 @@ group_by_grouping_sets
       type: "group_by_grouping_sets",
       groupingSetsKw: read(kw),
       columns,
+    });
+  }
+
+group_by_all
+  = kw:ALL {
+    return loc({
+      type: "group_by_all",
+      allKw: read(kw),
     });
   }
 

--- a/src/showNode/select.ts
+++ b/src/showNode/select.ts
@@ -104,6 +104,7 @@ export const selectMap: FullTransformMap<string, AllSelectNodes> = {
   group_by_rollup: (node) => show([node.rollupKw, node.columns]),
   group_by_cube: (node) => show([node.cubeKw, node.columns]),
   group_by_grouping_sets: (node) => show([node.groupingSetsKw, node.columns]),
+  group_by_all: (node) => show([node.allKw]),
   having_clause: (node) => show([node.havingKw, node.expr]),
   qualify_clause: (node) => show([node.qualifyKw, node.expr]),
   order_by_clause: (node) =>

--- a/test/select/group_by.test.ts
+++ b/test/select/group_by.test.ts
@@ -20,6 +20,12 @@ describe("select GROUP BY", () => {
     });
   });
 
+  dialect(["bigquery"], () => {
+    it("supports GROUP BY ALL", () => {
+      testClauseWc("GROUP BY ALL");
+    });
+  });
+
   dialect(["bigquery", "postgresql"], () => {
     it("supports GROUP BY ROLLUP()", () => {
       testClauseWc("GROUP BY ROLLUP ( id, name + age )");


### PR DESCRIPTION
Add support for BigQuery's GROUP BY ALL ([documentation](https://cloud.google.com/bigquery/docs/reference/standard-sql/query-syntax#group_by_clause), [release notes](https://cloud.google.com/bigquery/docs/release-notes#February_26_2024)).

I've checked, and just allowing keyword ALL would have been enough as well (there was no need to introduce a new `group_by_all` type). I introduced the new `group_by_all` type because I felt it was preferrable to be explicit, rather than relying on a solution that "worked by accident", but I'm a little hesitant about this. If you'd prefer the simple solution, feel free to use that instead. 

In addition, I also considered a separate GROUP BY ALL clause, which would have disallowed mixing GROUP BY ALL with elements from other syntax variants. I decided against this because you [wrote you didn't intend this to be an SQL validator](https://nene.github.io/2022/11/05/one-grammar-to-rule-them-all). 